### PR TITLE
Adding repo root as default path

### DIFF
--- a/example_streamlit_pythonocc.py
+++ b/example_streamlit_pythonocc.py
@@ -15,7 +15,7 @@ from multiprocessing import Queue
 
 class app():
     def __init__(self):
-        self.my_renderer = threejs_renderer_st.ThreejsRenderer()
+        self.my_renderer = threejs_renderer_st.ThreejsRenderer(path='.')
         self.queue = Queue()
         self.setup_streamlit()
         
@@ -74,3 +74,4 @@ if __name__ == '__main__':
 
 
 # streamlit run path_to_your_file/example_streamlit_pythonocc.py
+


### PR DESCRIPTION
This script won't work properly according to instructions if the 'path' is not explicitly added.
I am assuming that the temporary folder might be deleted following an update to the streamlit state.