### PR TITLE
Fix to the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install streamlit
 
 In your terminal, with your conda env activated, just type:
 ```
-streamlit run path_to_your_file/example_streamlit_pythonocc.py
+streamlit run <explicit path_to_your_repo>/example_streamlit_pythonocc.py
 ```
 
 ### Examples

--- a/example_streamlit_pythonocc.py
+++ b/example_streamlit_pythonocc.py
@@ -15,7 +15,7 @@ from multiprocessing import Queue
 
 class app():
     def __init__(self):
-        self.my_renderer = threejs_renderer_st.ThreejsRenderer(path='.')
+        self.my_renderer = threejs_renderer_st.ThreejsRenderer()
         self.queue = Queue()
         self.setup_streamlit()
         
@@ -74,4 +74,5 @@ if __name__ == '__main__':
 
 
 # streamlit run path_to_your_file/example_streamlit_pythonocc.py
+
 

--- a/example_streamlit_pythonocc.py
+++ b/example_streamlit_pythonocc.py
@@ -15,7 +15,7 @@ from multiprocessing import Queue
 
 class app():
     def __init__(self):
-        self.my_renderer = threejs_renderer_st.ThreejsRenderer()
+        self.my_renderer = threejs_renderer_st.ThreejsRenderer(path='.')
         self.queue = Queue()
         self.setup_streamlit()
         
@@ -74,3 +74,4 @@ if __name__ == '__main__':
 
 
 # streamlit run path_to_your_file/example_streamlit_pythonocc.py
+


### PR DESCRIPTION
This example won't work unless either is performed:
* Sending the `streamlit` an **explicit** path to the function (or it always try to launch the script from the temporary folder following a rendering.
 
 or
 
 * Defining a the repo's root in  `threejs_renderer_st.ThreejsRenderer(path='.')